### PR TITLE
mock-repo shouldn't have its own tslint

### DIFF
--- a/packages/mock-repo/src/composite/child.tsx
+++ b/packages/mock-repo/src/composite/child.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-export interface Props {
+export interface IProps {
   text: string;
 }
 
-export const ChildComp: React.SFC<Props> = (props: Props) => {
-  return <h1>{props.text}</h1>;
-};
+export const ChildComp: React.SFC<IProps> = (props) => <h1>{props.text}</h1>;

--- a/packages/mock-repo/src/modal/modal.tsx
+++ b/packages/mock-repo/src/modal/modal.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-interface ModalProps {
+interface IModalProps {
   children: React.ReactNode;
 }
 
-interface ModalState {
+interface IModalState {
   root: HTMLElement | null;
 }
 
-export class Modal extends React.Component<ModalProps, ModalState> {
-  public state: ModalState = {
+export class Modal extends React.Component<IModalProps, IModalState> {
+  public state: IModalState = {
     root: null
   };
 

--- a/packages/mock-repo/src/post-render-hook/post-render-hook.tsx
+++ b/packages/mock-repo/src/post-render-hook/post-render-hook.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
 
-export interface CompState {
+export interface IState {
   label: string;
 }
 
-export class PostRenderHook extends React.Component<{}, CompState> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      label: 'Label failed to change'
-    };
-  }
+export class PostRenderHook extends React.Component<{}, IState> {
+  public state: IState = {
+    label: 'Label failed to change'
+  };
 
   public componentDidMount() {
     this.setState({label: 'I mounted and changed my label'});

--- a/packages/mock-repo/test/node/index.node-spec.ts
+++ b/packages/mock-repo/test/node/index.node-spec.ts
@@ -2,6 +2,6 @@ import {expect} from 'chai';
 
 describe('Testing the node tests', () => {
   it('should work', () => {
-    expect(true).to.be.true;
+    expect(true).to.equal(true);
   });
 });

--- a/packages/mock-repo/tslint.json
+++ b/packages/mock-repo/tslint.json
@@ -1,6 +1,0 @@
-{
-    "extends": ["tslint-wix-react"],
-    "rules": {
-      "no-submodule-imports" : [true, "react-dom"]
-    }
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,59 +1,22 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es2017",
+    "module": "esnext",
     "lib": [
       "es2017"
-    ],                                        /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "react",                        /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-    "sourceMap": true,                        /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    ],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
 
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
 
-    /* Additional Checks */
-    "noUnusedLocals": true,                   /* Report errors on unused locals. */
-    "noUnusedParameters": false,              /* Report errors on unused parameters. */
-    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": [],                              /* Type declaration files to be included in compilation. */
-    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true                  /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "moduleResolution": "node",
+    "types": [],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
also removed comments from tsconfig.json because comments are not allowed in JSON, and in VSCode they turn the entire file into a large red squiggly underline.