### PR TITLE
TSLint: disable ridiculous rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,8 @@
         "quotemark": [
             true,
             "single",
-            "jsx-double"
+            "jsx-double",
+            "avoid-escape"
         ],
         "semicolon": [
             true,
@@ -24,7 +25,9 @@
             "allow-leading-underscore",
             "allow-pascal-case"
         ],
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "jsx-no-multiline-js": false,
+        "max-classes-per-file": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
* avoid-escape - allow to use double quotes around a string that contains single quotes. E.g. `"can't touch this"` instead of forcing you to write `'can\'t touch this'`.
* max-classes-per-file - allow multiple classes per file
* jsx-no-multiline-js - allow multiline expressions inside of JSX, e.g.:
```
<div>
    {items.map(it => (
        <div>{it.name}</div>
    ))}
</div>
```