### PR TITLE
Removed empty props ssr test

### DIFF
--- a/packages/sanity/src/ssr-test/ssr-test.tsx
+++ b/packages/sanity/src/ssr-test/ssr-test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment node
  */
-import React from 'react';
 import {renderToString} from 'react-dom/server';
 import Registry, {getCompName} from '@ui-autotools/registry';
 import {expect} from 'chai';
@@ -16,10 +15,6 @@ export const ssrTest = (): void => {
 
         Registry.metadata.components.forEach((componentMetadata, Comp) => {
             describe(getCompName(Comp), () => {
-                it(`should render component: "${getCompName(Comp)}" to string without throwing`, () => {
-                    expect(() => renderToString(<Comp />), 'RenderToString threw an error').not.to.throw();
-                });
-
                 componentMetadata.simulations.forEach(((simulation) => {
                     it(`should render component: "${getCompName(Comp)}" to string with props of simulation: "${simulation.title}" without throwing`, () => {
                         expect(() => renderToString(componentMetadata.simulationToJSX(simulation)), 'RenderToString threw an error').not.to.throw();


### PR DESCRIPTION
Since A: didn't make much sense to begin with. B: breaks with components that have required props.