### PR TITLE
Schema Extract - fix boolean enums

### DIFF
--- a/packages/schema-extract/src/file-transformer.ts
+++ b/packages/schema-extract/src/file-transformer.ts
@@ -649,7 +649,11 @@ const describeUnionType: TsNodeDescriber<ts.UnionTypeNode> = (decl, checker, env
     }
 
     if (specificBool) {
-        groupedSchemas.push(specificBool);
+        if (specificBool.enum!.length > 1) {
+            groupedSchemas.push({type: 'boolean'});
+        } else {
+            groupedSchemas.push(specificBool);
+        }
     }
 
     if (groupedSchemas.length > 1) {

--- a/packages/schema-extract/src/file-transformer.ts
+++ b/packages/schema-extract/src/file-transformer.ts
@@ -616,6 +616,7 @@ const describeUnionType: TsNodeDescriber<ts.UnionTypeNode> = (decl, checker, env
     const groupedSchemas: Schema[] = [];
     let specificString: Schema | undefined;
     let specificNumber: Schema | undefined;
+    let specificBool: Schema | undefined;
     schemas.forEach((s) => {
         if (s.type === 'string' && s.enum) {
             specificString = specificString || {
@@ -629,6 +630,12 @@ const describeUnionType: TsNodeDescriber<ts.UnionTypeNode> = (decl, checker, env
                 enum: [],
             };
             specificNumber.enum = specificNumber.enum!.concat(s.enum);
+        } else if (s.type === 'boolean' && s.enum) {
+            specificBool = specificBool || {
+                type: 'boolean',
+                enum: [],
+            };
+            specificBool.enum = specificBool.enum!.concat(s.enum);
         } else {
             groupedSchemas.push(s);
         }
@@ -639,6 +646,10 @@ const describeUnionType: TsNodeDescriber<ts.UnionTypeNode> = (decl, checker, env
 
     if (specificNumber) {
         groupedSchemas.push(specificNumber);
+    }
+
+    if (specificBool) {
+        groupedSchemas.push(specificBool);
     }
 
     if (groupedSchemas.length > 1) {

--- a/packages/schema-extract/test/primitives.spec.ts
+++ b/packages/schema-extract/test/primitives.spec.ts
@@ -110,7 +110,7 @@ describe('schema-extract - primitives', () => {
                                 {},
                                 {type: 'string', enum: ['hello']},
                                 {type: 'number', enum: [5]},
-                                {type: 'boolean', enum: [false, true]},
+                                {type: 'boolean'},
                             ]
                         }
                     }

--- a/packages/schema-extract/test/primitives.spec.ts
+++ b/packages/schema-extract/test/primitives.spec.ts
@@ -105,13 +105,12 @@ describe('schema-extract - primitives', () => {
                     properties: {
                             foobar: {
                             $oneOf: [
-                                {type: 'boolean', enum: [false]},
-                                {type: 'boolean', enum: [true]},
                                 {$ref: UndefinedSchemaId},
                                 {$ref: NullSchemaId},
                                 {},
                                 {type: 'string', enum: ['hello']},
-                                {type: 'number', enum: [5]}
+                                {type: 'number', enum: [5]},
+                                {type: 'boolean', enum: [false, true]},
                             ]
                         }
                     }


### PR DESCRIPTION
When we have both true and false as part of a union type, we split them. Now we are grouping them together and just use the boolean type instead of an enum. e.g:
`type weirdType = 'hello' | true | 'world' | false;`