### PR TITLE
Linker - support import chains

### DIFF
--- a/packages/schema-extract/src/file-linker.ts
+++ b/packages/schema-extract/src/file-linker.ts
@@ -42,7 +42,7 @@ export class SchemaLinker {
             return {refEntity: null, refEntityType: ref};
         }
         const poundIndex = ref.indexOf('#');
-        const cleanRef = ref.slice(poundIndex + 1);
+        const cleanRef = ref.slice(poundIndex + 1).replace('typeof ', '');
         if (!schema.definitions) {
             return {refEntity: null, refEntityType: cleanRef};
         }
@@ -53,8 +53,12 @@ export class SchemaLinker {
                         null;
         if (!refEntity) {
             const importSchema = this.getSchemaFromImport(ref.slice(0, poundIndex), ref.slice(poundIndex + 1));
-            if (importSchema && importSchema.definitions) {
-                refEntity = importSchema.definitions[cleanRef];
+            if (importSchema) {
+                if (importSchema.definitions) {
+                    refEntity = importSchema.definitions[cleanRef];
+                } else if (importSchema.properties) {
+                    refEntity = importSchema.properties[cleanRef];
+                }
             }
         }
         if (!refEntity) {

--- a/packages/schema-extract/src/json-schema-types.ts
+++ b/packages/schema-extract/src/json-schema-types.ts
@@ -77,6 +77,7 @@ export type ModuleSchema<T extends  SchemaTypes = SchemaTypes> = Schema<T> & {
     '$id': string,
     '$ref': typeof ModuleSchemaId,
     'definitions'?: {[name: string]: Schema},
+    'properties'?: {[name: string]: Schema},
 };
 
 export type FunctionSchema = Schema & {

--- a/packages/schema-extract/test/linker/imports.spec.ts
+++ b/packages/schema-extract/test/linker/imports.spec.ts
@@ -27,6 +27,32 @@ describe('schema-linker - imports', () => {
         expect(res).to.eql(expected);
     });
 
+    it('should link imported type definition from an import chain', async () => {
+        const fileName = 'index.ts';
+        const res = linkTest({
+            [fileName]: `
+                import {MyType} from './import1';
+                export type B = MyType<string>;`,
+            ['import1.ts']: `
+                export {MyType} from './import2'`,
+            ['import2.ts']: `
+                export type MyType<T> = {
+                    something:T;
+                };`
+        }, 'B', fileName);
+
+        const expected: Schema<'object'> = {
+            type: 'object',
+            properties: {
+                something: {
+                    type: 'string'
+                }
+            },
+            required: ['something']
+        };
+        expect(res).to.eql(expected);
+    });
+
     it('should link imported interfaces', async () => {
         const fileName = 'index.ts';
         const res = linkTest({


### PR DESCRIPTION
Added support for import chains, e.g.:
file1: `import {X} from 'file2.ts'`
file2: `export {X} from 'file3.ts'`
file3: `export type X = {...}`