### PR TITLE
Rashelle/declaration map typescript 2.9 addition

### DIFF
--- a/packages/mock-repo/.autotools/webpack.config.js
+++ b/packages/mock-repo/.autotools/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
           loader: 'ts-loader',
           options: {
             compilerOptions: {
-              declaration: false
+              declaration: false,
+              declarationMap: false
             }
           }
         }

--- a/packages/mock-repo/webpack.config.js
+++ b/packages/mock-repo/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
         options: {
           compilerOptions: {
             declaration: false,
+            declarationMap: false
           },
         },
       },

--- a/packages/showcase/src/tsconfig.json
+++ b/packages/showcase/src/tsconfig.json
@@ -8,6 +8,7 @@
     ],
     "jsx": "react",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "strict": true,
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     ],
     "jsx": "react",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "strict": true,
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
                 options: {
                     compilerOptions: {
                         declaration: false,
+                        declarationMap: false,
                         module: 'esnext'
                     }
                 }


### PR DESCRIPTION
declarationMap
Enabling --declarationMap alongside --declaration causes the compiler to emit .d.ts.map files alongside the output .d.ts files. Language Services can also now understand these map files, and uses them to map declaration-file based definition locations to their original source, when available.

In other words, hitting go-to-definition on a declaration from a .d.ts file generated with --declarationMap will take you to the source file (.ts) location where that declaration was defined, and not to the .d.ts.