### PR TITLE
Travis: test on both Linux and Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 sudo: required # needed for headless chrome's sandbox
-    
+
+os:
+  - linux
+  - osx
+
 node_js:
   - 10 # current
   - 8  # lts
@@ -9,8 +13,8 @@ cache:
   yarn: true
 
 # Travis has built-in yarn 1.3.2 atm.
-# We install 1.7.0 to be able to run bins from root node_modules
+# We install 1.9.4 to be able to run bins from root node_modules
 # in child projects (without having to specify them as dev deps in each project)
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/packages/sanity/test/ssr-test.spec.tsx
+++ b/packages/sanity/test/ssr-test.spec.tsx
@@ -35,7 +35,7 @@ describe('SSR Test', () => {
       expect(flag, 'Test did not pass with valid component').to.equal(1);
       done();
     });
-  }).timeout(3000);
+  }).timeout(5000);
 
   it('should fail with an invalid component', (done) => {
     Registry.getComponentMetadata(FailingTestComp);
@@ -43,5 +43,5 @@ describe('SSR Test', () => {
       expect(flag, 'Test did not fail with invalid component').to.equal(-1);
       done();
     });
-  }).timeout(3000);
+  }).timeout(5000);
 });


### PR DESCRIPTION
and use latest stable yarn 1.9.4
Mac feels pretty stable on Travis lately, so enable it