### PR TITLE
Linker - Temp React handling

### DIFF
--- a/packages/schema-extract/src/file-transformer.ts
+++ b/packages/schema-extract/src/file-transformer.ts
@@ -814,23 +814,13 @@ function serializeType(t: ts.Type, rootNode: ts.Node, checker: ts.TypeChecker, e
                 if (memoMap.has(propName)) {
                     res.properties![propName] = memoMap.get(propName);
                 } else {
-                    if (fieldType.symbol) {
-                        const tyepName = checker.getFullyQualifiedName(fieldType.symbol);
-                        if (circularSet && circularSet.has(tyepName)) {
-                            res.properties![propName] = {$ref: '#' + tyepName};
-                            break;
-                        }
-                        // const cSet = circularSet ? new Set(circularSet) : new Set();
-                        if (fieldType.symbol) {
-                            cSet.add(tyepName);
-                        }
-                        memoMap.set(propName, serializeType(fieldType, rootNode, checker, env, cSet, memoMap).schema);
-                        res.properties![propName] = memoMap.get(propName);
-                    } else {
-                        cSet.add(propName);
-                        memoMap.set(propName, serializeType(fieldType, rootNode, checker, env, cSet, memoMap).schema);
-                        res.properties![propName] = memoMap.get(propName);
+                    if (circularSet && circularSet.has(propName)) {
+                        res.properties![propName] = {$ref: '#' + propName};
+                        break;
                     }
+                    cSet.add(propName);
+                    memoMap.set(propName, serializeType(fieldType, rootNode, checker, env, cSet, memoMap).schema);
+                    res.properties![propName] = memoMap.get(propName);
                 }
             }
         }

--- a/packages/schema-extract/test/linker/funcitons.spec.ts
+++ b/packages/schema-extract/test/linker/funcitons.spec.ts
@@ -49,7 +49,7 @@ describe('schema-linker - functions', () => {
             genericParams: [{name: 'T'}],
             requiredArguments: ['o'],
             returns: {
-                type: 'object'
+                $ref: '#T'
             }
         };
         expect(res).to.eql(expected);

--- a/packages/schema-extract/test/linker/imports.spec.ts
+++ b/packages/schema-extract/test/linker/imports.spec.ts
@@ -3,7 +3,7 @@ import { Schema } from '../../src/json-schema-types';
 import {linkTest} from '../../test-kit/run-linker';
 
 describe('schema-linker - imports', () => {
-    it('should link imported type definition', async () => {
+    it('should link imported generic type definition', async () => {
         const fileName = 'index.ts';
         const res = linkTest({
             [fileName]: `
@@ -16,10 +16,13 @@ describe('schema-linker - imports', () => {
         }, 'B', fileName);
 
         const expected: Schema<'object'> = {
-            $ref: '/someProject/src/import#MyType',
-            genericArguments: [{
-                type: 'string'
-            }]
+            type: 'object',
+            properties: {
+                something: {
+                    type: 'string'
+                }
+            },
+            required: ['something']
         };
         expect(res).to.eql(expected);
     });


### PR DESCRIPTION
This is a temporary solution to handling imports. It will probably be changed when we decouple linker and schema extract.
Added a function to get the imported schema to schema-extract and fixed tests.
