### PR TITLE
Printing errors to console properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ autotools snap --files ./components/**/*.meta.ts
 
 #### Options
 
-- `skip-if-missing-key`: set this flag if you want to skip testing when `process.env.EYES_API_KEY` or `process.env.APPLITOOLS_API_KEY` variables are not set. By default, snap will fail if either of these keys are not set. Example usage: `snap --skip-if-missing-key`, or, `snap -s`.
+- `skip-on-missing-key`: set this flag if you want to skip testing when `process.env.EYES_API_KEY` or `process.env.APPLITOOLS_API_KEY` variables are not set. By default, snap will fail if either of these keys are not set. Example usage: `snap --skip-on-missing-key`, or, `snap -s`.
 
 ### Showcase
 

--- a/packages/sanity/src/hydration-test/server.tsx
+++ b/packages/sanity/src/hydration-test/server.tsx
@@ -49,7 +49,7 @@ export async function hydrationTest(
   } catch (error) {
     process.exitCode = 1;
     if (error) {
-      process.stderr.write(error.toString());
+      process.stderr.write(error.toString() + '\n');
     }
   } finally {
     if (server) {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -9,7 +9,7 @@ import {a11yTest, impactLevels} from '@ui-autotools/a11y';
 import {buildWebsite, startWebsite} from '@ui-autotools/showcase';
 import ssrTest from './ssr-test/mocha-wrapper';
 import {importMetaFiles} from './import-meta-files';
-import {registerRequireHooks, consoleError} from '@ui-autotools/utils';
+import {registerRequireHooks} from '@ui-autotools/utils';
 
 dotenv.config();
 registerRequireHooks();

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -57,8 +57,8 @@ program
   } catch (error) {
     process.exitCode = 1;
     if (error) {
-      consoleError(error);
-      process.stderr.write(error.toString());
+      // Without a new-line, the error will not show on certain node versions
+      process.stderr.write(error.toString() + '\n');
     }
   }
 });

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -9,7 +9,7 @@ import {a11yTest, impactLevels} from '@ui-autotools/a11y';
 import {buildWebsite, startWebsite} from '@ui-autotools/showcase';
 import ssrTest from './ssr-test/mocha-wrapper';
 import {importMetaFiles} from './import-meta-files';
-import {registerRequireHooks} from '@ui-autotools/utils';
+import {registerRequireHooks, consoleError} from '@ui-autotools/utils';
 
 dotenv.config();
 registerRequireHooks();
@@ -57,6 +57,7 @@ program
   } catch (error) {
     process.exitCode = 1;
     if (error) {
+      consoleError(error);
       process.stderr.write(error.toString());
     }
   }

--- a/packages/showcase/src/server/index.ts
+++ b/packages/showcase/src/server/index.ts
@@ -215,7 +215,7 @@ export async function buildWebsite(
       throw websiteStats.toString();
     }
   } catch (e) {
-    process.stderr.write(e);
+    process.stderr.write(e + '\n');
     process.exit(1);
   }
 }

--- a/packages/utils/src/serve/log.ts
+++ b/packages/utils/src/serve/log.ts
@@ -66,7 +66,7 @@ export class Log {
 
   public compilationError(error: Error) {
     process.stderr.write(chalk.red('Compilation failed.\n'));
-    process.stderr.write(error.toString());
+    process.stderr.write(error.toString() + '\n');
   }
 
   public serverListening = (url: string) => {


### PR DESCRIPTION
With certain yarn versions, printing to `stderr` without a newline at the end results in the error being swallowed. This fixes issues on wix-ui-core CI too.

https://github.com/yarnpkg/yarn/issues/5005