### PR TITLE
[WIP] Initial POC of user config

### DIFF
--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -9,15 +9,28 @@ import {a11yTest, impactLevels} from '@ui-autotools/a11y';
 import {buildWebsite, startWebsite} from '@ui-autotools/showcase';
 import ssrTest from './ssr-test/mocha-wrapper';
 import {importMetaFiles} from './import-meta-files';
-import {registerRequireHooks} from '@ui-autotools/utils';
+import {getUserConfig, registerRequireHooks} from '@ui-autotools/utils';
 
 dotenv.config();
-registerRequireHooks();
 
 const program = new Command();
 const projectPath = process.cwd();
 const defaultMetaGlob = 'src/**/*.meta.ts?(x)';
+
 const webpackConfigPath = path.join(projectPath, '.autotools/webpack.config.js');
+const userConfigPath = path.join(projectPath, '.autotools/config.js');
+
+const config = getUserConfig(userConfigPath);
+
+// Setup user config
+if (config.setup) {
+  config.setup();
+}
+
+// Setup default require hooks if needed
+if (config.initializeRequireHooks) {
+  registerRequireHooks();
+}
 
 program
 .command('sanity')

--- a/packages/utils/src/get-user-config.ts
+++ b/packages/utils/src/get-user-config.ts
@@ -1,0 +1,23 @@
+interface IUserConfig {
+  setup?: () => void;
+  initializeRequireHooks?: boolean;
+}
+
+const defaultUserConfig: IUserConfig = {
+  initializeRequireHooks: true
+};
+
+export function getUserConfig(configPath: string): IUserConfig {
+  let userConfig: IUserConfig = {};
+
+  try {
+    userConfig = require(configPath) as IUserConfig;
+  } catch (e) {
+    // fallthrough
+  }
+
+  return {
+    ...defaultUserConfig,
+    ...userConfig
+  };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,6 +3,7 @@ export {WebpackConfigurator} from './webpack';
 export {waitForPageError, logConsoleMessages, runTestsInPuppeteer} from './puppeteer';
 export * from './console';
 export * from './get-project-name';
+export * from './get-user-config';
 export * from './http';
 export * from './raw-asset-webpack-plugin';
 export {registerRequireHooks} from './require-hooks/require-hooks';


### PR DESCRIPTION
This is a small POC of a user config feature. Initially, this was intended to allow the support for JavaScript files in the `sanity` tool by setting up custom require hooks.

An example config file that allows JavaScript support with css-modules require hooks is as follows:

```js
const {wixCssModulesRequireHook} = require('yoshi-runtime');
const {attachHook} = require('@stylable/node');

module.exports = {
  setup() {

    // Setup require hook for babel
    require('yoshi/src/require-hooks');

    // Setup require hook for css modules
    wixCssModulesRequireHook('./src');

    // Setup Stylable
    attachHook({});
  },

  // Disable `autotools`' default TypeScript and Stylable require hooks
  initializeRequireHooks: false
};
```

### Why not adding these require hooks directly in `autotools`?

* Some project relies on different versions of `yoshi` and `babel`, so it'll be better if the consumers will handle this by themselves.

* This will spare the addition of more dependencies to `autotools`.