### PR TITLE
schema-playground: preserve state between page reloads

### DIFF
--- a/packages/schema-playground/src/editor.tsx
+++ b/packages/schema-playground/src/editor.tsx
@@ -22,9 +22,9 @@ export interface IEditorProps {
   onChange: (newValue: string) => void;
 }
 
-function createFileModel(fs: IFileSystem, filePath: string) {
+function createFileModel(filePath: string, fileContents: string) {
   return editor.createModel(
-    fs.readFileSync(filePath),
+    fileContents,
     undefined,
     Uri.parse('file://' + filePath)
   );
@@ -68,7 +68,10 @@ export class Editor extends React.PureComponent<IEditorProps> {
     });
 
     this.editor = editor.create(this.domNode.current!, editorOptions);
-    this.editor.setModel(createFileModel(this.props.fs, this.props.filePath));
+    this.editor!.setModel(createFileModel(
+      this.props.filePath,
+      this.props.fs.readFileSync(this.props.filePath)
+    ));
     this.editor.onDidChangeModelContent(this.handleChange);
 
     window.addEventListener('resize', this.handleResize);
@@ -82,7 +85,10 @@ export class Editor extends React.PureComponent<IEditorProps> {
 
   public componentDidUpdate() {
     this.editor!.getModel()!.dispose();
-    this.editor!.setModel(createFileModel(this.props.fs, this.props.filePath));
+    this.editor!.setModel(createFileModel(
+      this.props.filePath,
+      this.props.fs.readFileSync(this.props.filePath)
+    ));
   }
 
   public render() {

--- a/packages/schema-playground/src/index.tsx
+++ b/packages/schema-playground/src/index.tsx
@@ -5,6 +5,7 @@ import { createMemoryFs } from '@file-services/memory';
 import { createBaseHost, createLanguageServiceHost } from '@file-services/typescript';
 import { Playground } from './playground';
 import { compilerOptions } from './compiler-options';
+import * as Session from './session';
 import {
     sampleTypescriptFilePath,
     sampleTypescriptFile,
@@ -26,8 +27,14 @@ async function main() {
     fs.populateDirectorySync('/', reactRecipe);
 
     // add initial sample files
-    fs.writeFileSync(sampleTypescriptFilePath, sampleTypescriptFile);
-    fs.writeFileSync(sampleStylableFilePath, sampleStylableFile);
+    fs.writeFileSync(
+        sampleTypescriptFilePath,
+        Session.loadFile(sampleTypescriptFilePath) || sampleTypescriptFile
+    );
+    fs.writeFileSync(
+        sampleStylableFilePath,
+        Session.loadFile(sampleStylableFilePath) || sampleStylableFile
+    );
 
     // initialize hosts
     const baseHost = createBaseHost(fs, '/');

--- a/packages/schema-playground/src/playground.tsx
+++ b/packages/schema-playground/src/playground.tsx
@@ -6,6 +6,7 @@ import {transform} from '@ui-autotools/schema-extract';
 import {extractSchema as extractStylableSchema} from '@stylable/schema-extract';
 import {BaseView as BaseSchemaView, defaultSchemaViewRegistry} from '@ui-autotools/schema-views/src';
 import {Editor} from './editor';
+import * as Session from './session';
 
 import 'sanitize.css';
 import './playground.css';
@@ -24,7 +25,7 @@ export interface IPlaygroundState {
 
 export class Playground extends React.PureComponent<IPlaygroundProps, IPlaygroundState> {
   public state = {
-    fileType: 'typescript',
+    fileType: Session.loadSetting('fileType') || 'typescript',
     schema: {}
   };
 
@@ -75,12 +76,16 @@ export class Playground extends React.PureComponent<IPlaygroundProps, IPlaygroun
   }
 
   private handleFileTypeChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    this.setState({fileType: e.target.value});
+    const fileType = e.target.value;
+    this.setState({fileType});
+    Session.saveSetting('fileType', fileType);
     requestAnimationFrame(() => this.updateSchema());
   }
 
   private handleSourceCodeChange = (newValue: string) => {
-    this.props.fs.writeFileSync(this.getFilePath(), newValue);
+    const filePath = this.getFilePath();
+    this.props.fs.writeFileSync(filePath, newValue);
+    Session.saveFile(filePath, newValue);
     this.forceUpdate();
     requestAnimationFrame(() => this.updateSchema());
   }

--- a/packages/schema-playground/src/session.ts
+++ b/packages/schema-playground/src/session.ts
@@ -1,0 +1,17 @@
+const getFileKey = (filePath: string): string =>
+  'schema-playground-file: ' + filePath;
+
+const getSettingKey = (settingName: string): string =>
+  'schema-playground-setting: ' + settingName;
+
+export const loadSetting = (name: string): string | null =>
+  window.sessionStorage.getItem(getSettingKey(name));
+
+export const saveSetting = (name: string, value: string): void =>
+  window.sessionStorage.setItem(getSettingKey(name), value);
+
+export const loadFile = (filePath: string): string | null =>
+  window.sessionStorage.getItem(getFileKey(filePath));
+
+export const saveFile = (filePath: string, content: string): void =>
+  window.sessionStorage.setItem(getFileKey(filePath), content);


### PR DESCRIPTION
Preserve selected file type and its content between page reloads.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [ ] Patch
- [x] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
