### PR TITLE
Small refactor of require hooks

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -13,8 +13,8 @@
     "build:cjs-watch": "tsc --watch -p src --outDir cjs --module commonjs",
     "build:esm-watch": "tsc --watch -p src --outDir esm --module esnext",
     "lint": "tslint -p src",
-    "test": "mocha -r @ts-tools/node \"./test/**/*.spec.ts?(x)\"",
-    "test:watch": "mocha -r @ts-tools/node \"./test/**/*.spec.ts?(x)\" --watch --watch-extensions ts,tsx"
+    "test": "mocha -r @ts-tools/node -r @stylable/node/register \"./test/**/*.spec.ts?(x)\"",
+    "test:watch": "mocha -r @ts-tools/node -r @stylable/node/register \"./test/**/*.spec.ts?(x)\" --watch --watch-extensions ts,tsx"
   },
   "files": [
     "cjs",

--- a/packages/snap/test/generate-index-files.spec.ts
+++ b/packages/snap/test/generate-index-files.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import {MockRegistry} from '@ui-autotools/test-kit';
 import {generateIndexFileData} from '../src/generate-snapshots/build-base-files';
 

--- a/packages/test-kit/src/registry/mock-registry.ts
+++ b/packages/test-kit/src/registry/mock-registry.ts
@@ -1,5 +1,3 @@
-import {registerRequireHooks} from '@ui-autotools/utils';
-registerRequireHooks();
 import Registry, { ISimulation } from '@ui-autotools/registry';
 import {MockComp} from './fixtures/mock-comp';
 import style from './fixtures/variant.st.css';

--- a/packages/utils/src/require-hooks/require-hooks.ts
+++ b/packages/utils/src/require-hooks/require-hooks.ts
@@ -1,6 +1,4 @@
-import '@ts-tools/node';
-import {attachHook} from '@stylable/node';
-
 export function registerRequireHooks() {
-  attachHook({});
+  require('@ts-tools/node');
+  require('@stylable/node/register');
 }


### PR DESCRIPTION
## Describe this Pull Request

1. Importing `registerRequireHooks` used to register `.ts` hook even if you don't run the function.
2. `mock-registry.ts` was registering the hooks, which should only be done by top-level scripts of CLI tools.


## Additional information
(Type `X` in the relevant boxes)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] None of the above

### Versioning required due to this change
- [x] Patch
- [ ] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
