### PR TITLE
Don't fail snap if machine is not on CI

### DIFF
--- a/packages/mock-repo/is-ci.ts
+++ b/packages/mock-repo/is-ci.ts
@@ -1,7 +1,14 @@
 import isCI from 'is-ci';
+import {exec} from 'child_process';
 
 if (isCI) {
-  process.exit(0);
-} else {
-  process.exit(1);
+  exec('yarn autotools snap', (err, stdout, stderr) => {
+    if (err) {
+      // tslint:disable-next-line:no-console
+      console.error(err);
+    }
+
+    process.stdout.write(stdout);
+    process.stderr.write(stderr);
+  });
 }


### PR DESCRIPTION
## Describe this Pull Request
We were exiting the process with 1 if not on CI. Now we're not.


## Additional information
(Type `X` in the relevant boxes)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [x] Patch
- [ ] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
