### PR TITLE
Disable github integration since it breaks ui-core: can't find .git

### DIFF
--- a/packages/snap/src/snap-test/snap.ts
+++ b/packages/snap/src/snap-test/snap.ts
@@ -7,8 +7,6 @@ import {JSDOM} from 'jsdom';
 import {consoleLog} from '@ui-autotools/utils';
 import {parseSnapshotFilename} from '../generate-snapshots/filename-utils';
 import {IFileInfo} from '../generate-snapshots/build-base-files';
-import {setApplitoolsBatchId} from './set-batch-id';
-import {getBranchName} from '@ui-autotools/node-utils';
 
 interface ITestResult {
   status: 'error' | 'new' | 'modified' | 'unmodified';
@@ -22,9 +20,7 @@ function getGridClientConfig(projectPath: string) {
     throw new Error('The project should have a package.json file with a "name" field.');
   }
 
-  const batchId = setApplitoolsBatchId();
-
-  const branchName = projectName + '/' + getBranchName();
+  const branchName = projectName + '/master';
   const viewportWidth = 1050;
   const viewportHeight = 1075;
 
@@ -32,7 +28,6 @@ function getGridClientConfig(projectPath: string) {
     appName: projectName,
     apiKey: process.env.APPLITOOLS_API_KEY || process.env.EYES_API_KEY,
     branchName,
-    batchId,
     batchName: projectName,
     browser: {
       name: 'chrome',


### PR DESCRIPTION
https://tc.dev.wixpress.com/viewLog.html?buildId=75111007&buildTypeId=WixUi_Packages_WixUiCore&tab=buildLog&_focus=4480#_state=435

```
[12:24:57][npm run test] > autotools snap --skip-on-missing-key
[12:24:57][npm run test] 
[12:25:23][npm run test] Warning: falling back to using process.env.EYES_API_KEY, please set process.env.APPLITOOLS_API_KEY instead.
[12:25:23][npm run test] Building base files...
[12:25:23][npm run test] Generating snapshots...
[12:25:28][npm run test] fatal: Not a git repository (or any of the parent directories): .git
[12:25:28][npm run test] fatal: Not a git repository (or any of the parent directories): .git
[12:25:28][npm run test] Error: Command failed: git rev-parse --abbrev-ref HEAD
[12:25:28][npm run test] fatal: Not a git repository (or any of the parent directories): .git
[12:25:28][npm run test] 
[12:25:29][npm run test] npm ERR! code ELIFECYCLE
[12:25:29][npm run test] npm ERR! errno 1
[12:25:29][npm run test] npm ERR! wix-ui-core@2.0.0 snap: `autotools snap --skip-on-missing-key`
[12:25:29][npm run test] npm ERR! Exit status 1
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Versioning required due to this change
- [x] Minor

### Does this change the API or main functionality
- [x] No
