### PR TITLE
schema-views: add support for view variants, fix runtime errors

### DIFF
--- a/packages/schema-views/src/default-registry.ts
+++ b/packages/schema-views/src/default-registry.ts
@@ -18,5 +18,6 @@ registry.registerView(views.NullTypeView, predicates.isNull);
 registry.registerView(views.AnyTypeView, predicates.isAny);
 
 registry.registerView(views.ModuleView, predicates.isModule);
+registry.registerView(views.InterfaceView, predicates.isInterface, 'expanded');
 
 export const defaultSchemaViewRegistry = registry;

--- a/packages/schema-views/src/schema-view-registry.ts
+++ b/packages/schema-views/src/schema-view-registry.ts
@@ -2,18 +2,34 @@ import {Schema} from './schema';
 import {SchemaView} from './schema-view';
 import {SchemaPredicate} from './schema-predicates';
 
-export class SchemaViewRegistry {
-  private views: Array<{view: SchemaView, predicate: SchemaPredicate}> = [];
+interface IViewRegistration {
+  view: SchemaView;
+  predicate: SchemaPredicate;
+  variant?: string;
+}
 
-  public registerView(view: SchemaView, predicate: SchemaPredicate): void {
-    this.views.unshift({view, predicate});
+export class SchemaViewRegistry {
+  private views: IViewRegistration[] = [];
+
+  public registerView(view: SchemaView, predicate: SchemaPredicate, variant?: string): void {
+    this.views.unshift({view, predicate, variant});
   }
 
-  public getViewForSchema(schema: Schema): SchemaView {
-    const match = this.views.find(({predicate}) => predicate(schema));
+  public getViewForSchema(schema: Schema, variant?: string): SchemaView {
+    const match = variant ?
+      this.findView(schema, variant) || this.findView(schema) :
+      this.findView(schema);
+
     if (match) {
       return match.view;
     }
+
     throw new Error('No matching view found for schema');
+  }
+
+  private findView(schema: Schema, variant?: string) {
+    return this.views.find((view) =>
+      view.variant === variant && view.predicate(schema)
+    );
   }
 }

--- a/packages/schema-views/src/views/base.tsx
+++ b/packages/schema-views/src/views/base.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import {ISchemaViewProps} from '../schema-view';
 
 export const BaseView: React.FunctionComponent<ISchemaViewProps> = (props) => {
-  const View = props.viewRegistry.getViewForSchema(props.schema);
+  const View = props.viewRegistry.getViewForSchema(props.schema, props.variant);
   return <View {...props} />;
 };

--- a/packages/schema-views/src/views/expanded/interface.tsx
+++ b/packages/schema-views/src/views/expanded/interface.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {BaseView} from '../base';
+import {ISchemaViewProps} from '../../schema-view';
+import style from './table.st.css';
+import {Schema} from '../../schema';
+
+export const InterfaceView: React.SFC<ISchemaViewProps> = (props) => {
+  const {schema} = props;
+
+  const requiredProps: string[] = schema.required || [];
+  const properties: Schema[]  = schema.properties || [];
+
+  const entries =
+    Object.entries(properties).map(([propName, propSchema]) => {
+      const name = propName;
+      const description = propSchema.description || '';
+      const isRequired = requiredProps.includes(propName);
+      const type = (
+        <BaseView
+          schemaRegistry={props.schemaRegistry}
+          viewRegistry={props.viewRegistry}
+          schema={propSchema}
+        />
+      );
+
+      return {name, isRequired, type, description};
+    });
+
+  return (
+    <table {...style('root', {}, props)}>
+      <thead>
+        <tr>
+          <th className={style.header}>Name</th>
+          <th className={style.header}>Type</th>
+          <th className={style.header}>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(({name, isRequired, type, description}) =>
+          <tr key={name}>
+            <td className={style.propName}>
+              {name}{isRequired ? '' : '?'}
+            </td>
+            <td className={style.propType}>
+              {type}
+            </td>
+            <td className={style.propDescription}>
+              {description}
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};

--- a/packages/schema-views/src/views/expanded/module.tsx
+++ b/packages/schema-views/src/views/expanded/module.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {ISchemaViewProps} from '../schema-view';
-import { BaseView } from './base';
+import {ISchemaViewProps} from '../../schema-view';
+import { BaseView } from '../base';
 
 export const ModuleView: React.FunctionComponent<ISchemaViewProps> = (props) => {
   const definitions = {...props.schema.properties, ...props.schema.definitions};
@@ -11,6 +11,7 @@ export const ModuleView: React.FunctionComponent<ISchemaViewProps> = (props) => 
         schema={defSchema}
         schemaRegistry={props.schemaRegistry}
         viewRegistry={props.viewRegistry}
+        variant="expanded"
       />
     </div>
   ));

--- a/packages/schema-views/src/views/expanded/table.st.css
+++ b/packages/schema-views/src/views/expanded/table.st.css
@@ -1,0 +1,29 @@
+.root {
+  border-collapse: collapse;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.header, .propName, .propType, .propDescription {
+  text-align: left;
+  vertical-align: middle;
+  padding: 10px 16px 10px 10px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.header {
+  color: #777;
+  font-weight: 500;
+}
+
+.propName, .propType, .propDefaultValue {
+  font: 13px/1.5 Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.propType {
+  color: #932981;
+}
+
+.propDescription {
+  white-space: pre-wrap;
+}

--- a/packages/schema-views/src/views/index.ts
+++ b/packages/schema-views/src/views/index.ts
@@ -13,4 +13,5 @@ export {StringTypeView} from './types/string';
 export {UndefinedTypeView} from './types/undefined';
 export {UnionTypeView} from './types/union';
 
-export {ModuleView} from './module';
+export {ModuleView} from './expanded/module';
+export {InterfaceView} from './expanded/interface';

--- a/packages/schema-views/src/views/types/object.tsx
+++ b/packages/schema-views/src/views/types/object.tsx
@@ -3,6 +3,7 @@ import {intersperse} from '../../utils';
 import {BaseView} from '../base';
 import {ISchemaViewProps} from '../../schema-view';
 import {isValidJsIdentifier} from '../../utils';
+import {Schema} from '../../schema';
 import style from './type.st.css';
 
 const renderObjectKey = (key: string) =>
@@ -12,9 +13,10 @@ export const ObjectTypeView: React.FunctionComponent<ISchemaViewProps> = (props)
   const {schema} = props;
 
   const required: string[] = schema.required || [];
+  const properties: Schema[] = schema.properties || [];
 
   const entries: React.ReactNode[] =
-    Object.entries(schema.properties).map(([propName, propSchema]) => {
+    Object.entries(properties).map(([propName, propSchema]) => {
       const optional = required.includes(propName) ? '' : '?';
       return (
         <React.Fragment key={propName}>


### PR DESCRIPTION
* Add support for view variants (summary, expanded, etc)
* Add expanded view for interfaces
* Fix runtime errors related to `.properties` access in schemas without that key

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [x] Patch
- [ ] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
