### PR TITLE
Sanity - use render if hydrate does not exist

### DIFF
--- a/packages/sanity/src/hydration-test/hydration-test.tsx
+++ b/packages/sanity/src/hydration-test/hydration-test.tsx
@@ -4,7 +4,8 @@ import Registry, {getCompName} from '@ui-autotools/registry';
 import chai, {expect} from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import {hydrate} from 'react-dom';
+
+const hydrate = ReactDOM.hydrate || ReactDOM.render;
 
 chai.use(sinonChai);
 
@@ -30,7 +31,8 @@ export const hydrationTest = (): void => {
 
         if (!componentMetadata.nonHydrationTestCompliant) {
           componentMetadata.simulations.forEach((simulation) => {
-            it(`should hydrate component: "${getCompName(Comp)}" in strict mode, with props of simulation: "${simulation.title}" without errors`, () => {
+            const testMessage = `should ${ReactDOM.hydrate ? 'hydrate' : 'render'} component: "${getCompName(Comp)}"${componentMetadata.nonReactStrictModeCompliant ? '' : ' in strict mode'}, with props of simulation: "${simulation.title}" without errors`;
+            it(testMessage, () => {
               // Set root's HTML to the SSR component
               root.innerHTML = componentStrings[index];
               if (componentMetadata.nonReactStrictModeCompliant) {


### PR DESCRIPTION
## Describe this Pull Request
Fixed hydration tests to only render the component if hydrate doesn't exist on react-dom. Also changed the test message to tell if strict mode was used or not.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [x] Patch
- [ ] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
