### PR TITLE
linker - handle extends chain in refs

### DIFF
--- a/packages/schema-extract/src/file-linker.ts
+++ b/packages/schema-extract/src/file-linker.ts
@@ -85,7 +85,7 @@ export class SchemaLinker {
                 }
                 if ((isInterfaceSchema(refEntity) || isClassSchema(refEntity)) && refEntity.extends) {
                     refEntity.extends.$ref = refEntity.extends.$ref!.replace('#', `${ref.slice(0, poundIndex)}#`);
-                    refEntity = this.link(refEntity);
+                    refEntity = this.link(refEntity, paramsMap);
                 }
             }
         }
@@ -98,6 +98,9 @@ export class SchemaLinker {
             return this.getRefEntity(refEntity.$ref, paramsMap);
         }
         refEntity.definedAt = refEntity.definedAt || '#' + cleanRef;
+        if ((isInterfaceSchema(refEntity) || isClassSchema(refEntity)) && refEntity.extends && !refEntity.genericParams) {
+            refEntity = this.link(refEntity, paramsMap);
+        }
 
         return {refEntity, refEntityType: cleanRef};
     }

--- a/packages/schema-extract/src/file-linker.ts
+++ b/packages/schema-extract/src/file-linker.ts
@@ -98,6 +98,9 @@ export class SchemaLinker {
             return this.getRefEntity(refEntity.$ref, paramsMap);
         }
         refEntity.definedAt = refEntity.definedAt || '#' + cleanRef;
+
+        // There is something weird happening with interfaces and this is why we need !refEntity.genericParams
+        // We probably need to change something in linkInterface or move this logic there
         if ((isInterfaceSchema(refEntity) || isClassSchema(refEntity)) && refEntity.extends && !refEntity.genericParams) {
             refEntity = this.link(refEntity, paramsMap);
         }


### PR DESCRIPTION
## Describe this Pull Request
If a schema references to a class or interface that extend something else, it doesn't always continue linking and stops at the first "level".
fixed getRefEntity to link if refEntity extends something else

<!-- ## Additional information (Type `X` in the relevant boxes
-->

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [ ] Patch
- [x] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
