### PR TITLE
registry - allow dot in comp name

### DIFF
--- a/packages/registry/src/registry/registry.ts
+++ b/packages/registry/src/registry/registry.ts
@@ -15,7 +15,7 @@ const Registry: IRegistry = {
     }
 
     if (!isValidComponentName(newCompName)) {
-      throw new Error('Component names must be alphanumeric.');
+      throw new Error('Component names (displayName | name) are allowed to have only alphanumeric characters or dots.');
     }
 
     if (!this.metadata.components.has(comp)) {

--- a/packages/registry/src/utils/verify-string.ts
+++ b/packages/registry/src/utils/verify-string.ts
@@ -5,7 +5,7 @@ export function isValidSimulationTitle(stringToVerify: string): boolean {
 }
 
 export function isValidComponentName(stringToVerify: string): boolean {
-  const verificationExpression =  /^[a-zA-Z]+$/; // Match only letters
+  const verificationExpression =  /^[a-zA-Z\.]+$/; // Match only letters & dot
 
   return verificationExpression.test(stringToVerify);
 }

--- a/packages/registry/test/utils-tests/verify-string.spec.ts
+++ b/packages/registry/test/utils-tests/verify-string.spec.ts
@@ -28,5 +28,11 @@ describe('Verification Methods', () => {
 
       expect(isValidComponentName(badString)).to.equal(false);
     });
+
+    it('should return valid for a name with a dot', () => {
+      const validString = 'Shamefully.Named';
+
+      expect(isValidComponentName(validString)).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
## Describe this Pull Request

Allow dot (`.`) in the component name (usually `disaplyName`)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [ ] Patch
- [x] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
