### PR TITLE
hydrate to fallback to render for react15

### DIFF
--- a/packages/sanity/src/hydration-test/event-listener-test.tsx
+++ b/packages/sanity/src/hydration-test/event-listener-test.tsx
@@ -3,10 +3,11 @@ import ReactDOM from 'react-dom';
 import Registry, {getCompName} from '@ui-autotools/registry';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
-import {hydrate} from 'react-dom';
 import {AllEvents} from './all-events';
 import {attachEventListenerLogger} from './override-event-listeners';
 import {Listener} from './listener';
+
+const hydrate = ReactDOM.hydrate || ReactDOM.render;
 
 chai.use(sinonChai);
 


### PR DESCRIPTION
EventListener test is failing for react15 code (We are still using React 15.5 in wix-style-react):
```TypeError: react_dom_2.hydrate is not a function```

I am trying in this PR to fallback to `render` like you did in the [hydration test](https://github.com/wix-incubator/ui-autotools/blob/83dca403eac9514249ba60df52d3354b50f80f3a/packages/sanity/src/hydration-test/hydration-test.tsx#L8)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] None of the above

### Versioning required due to this change
- [x] Patch
- [ ] Minor
- [ ] Major

### Does this change the API or main functionality
- [ ] Yes and I updated README.md
- [x] No
